### PR TITLE
Add missing vector marker implementation

### DIFF
--- a/X11/overlay.cpp
+++ b/X11/overlay.cpp
@@ -134,7 +134,27 @@ XColor createXColorFromRGBA(short red, short green, short blue, short alpha) {
     *(&color.pixel) = ((*(&color.pixel)) & 0x00ffffff) | (alpha << 24);
     return color;
 }
-
+XColor parse_color(char* color_code) {
+    XColor color;
+    if (color_code[0] == '#') {
+        unsigned int r, g, b;
+        sscanf(color_code, "#%02x%02x%02x", &r, &g, &b);
+        color = createXColorFromRGBA(r, g, b, 255);
+    } else if (strcmp(color_code, "red") == 0) {
+        color = red;
+    } else if (strcmp(color_code, "green") == 0) {
+        color = green;
+    } else if (strcmp(color_code, "yellow") == 0) {
+        color = yellow;
+    } else if (strcmp(color_code, "blue") == 0) {
+        color = blue;
+    } else if (strcmp(color_code, "black") == 0) {
+        color = black;
+    } else {
+        color = white;
+    }
+    return color;
+}
 // Create a window
 void createShapedWindow() {
     XSetWindowAttributes wattr;
@@ -253,28 +273,6 @@ void sighandler(int signum) {
         cout << "edmcoverlay2: SIGINT/SIGTERM, exiting" << endl;
         exit(0);
     }
-}
-
-XPixel parse_color(char* color_code) {
-    XPixel color;
-    if (color_code[0] == '#') {
-        unsigned int r, g, b;
-        sscanf(color_code, "#%02x%02x%02x", &r, &g, &b);
-        color = createXColorFromRGBA(r, g, b, 255);
-    } else if (strcmp(color_code, "red") == 0) {
-        color = red.pixel;
-    } else if (strcmp(color_code, "green") == 0) {
-        color = green.pixel;
-    } else if (strcmp(color_code, "yellow") == 0) {
-        color = yellow.pixel;
-    } else if (strcmp(color_code, "blue") == 0) {
-        color = blue.pixel;
-    } else if (strcmp(color_code, "black") == 0) {
-        color = black.pixel;
-    } else {
-        color = white.pixel;
-    }
-    return color;
 }
 
 int main(int argc, char* argv[]) {
@@ -419,12 +417,12 @@ int main(int argc, char* argv[]) {
                 } else {
                     XSetFont(g_display, gc, normalfont->fid);
                 }
-                main_color = get_color(drawitem.text.color);
+                main_color = parse_color(drawitem.text.color);
                 XSetForeground(g_display, gc, main_color.pixel);
                 XDrawString(g_display, g_win, gc, SCALE_X(drawitem.text.x), SCALE_Y(drawitem.text.y), drawitem.text.text, strlen(drawitem.text.text));
             } else {
                 /* cout << "edmcoverlay2: drawing a shape" << endl; */
-                main_color = get_color(drawitem.shape.color);
+                main_color = parse_color(drawitem.shape.color);
                 XSetForeground(g_display, gc, main_color.pixel);
                 if (strcmp(drawitem.shape.shape, "rect") == 0) {
                     /* cout << "edmcoverlay2: specifically, a rect" << endl; */
@@ -459,7 +457,7 @@ int main(int argc, char* argv[]) {
                         }
 
                         if (strcmp(color, "") != 0) {
-                            XColor marker_color = get_color(color);
+                            XColor marker_color = parse_color(color);
                             XSetForeground(g_display, gc, marker_color.pixel);
                             if (type != nullptr) {
                                 if (strcmp(type, "circle") == 0) {

--- a/X11/overlay.cpp
+++ b/X11/overlay.cpp
@@ -255,6 +255,27 @@ void sighandler(int signum) {
     }
 }
 
+XPixel parse_color(char* color_code) {
+    XPixel color;
+    if (color_code[0] == '#') {
+        unsigned int r, g, b;
+        sscanf(color_code, "#%02x%02x%02x", &r, &g, &b);
+        color = createXColorFromRGBA(r, g, b, 255);
+    } else if (strcmp(color_code, "red") == 0) {
+        color = red.pixel;
+    } else if (strcmp(color_code, "green") == 0) {
+        color = green.pixel;
+    } else if (strcmp(color_code, "yellow") == 0) {
+        color = yellow.pixel;
+    } else if (strcmp(color_code, "blue") == 0) {
+        color = blue.pixel;
+    } else if (strcmp(color_code, "black") == 0) {
+        color = black.pixel;
+    } else {
+        color = white.pixel;
+    }
+    return color;
+}
 
 int main(int argc, char* argv[]) {
     if (argc != 5) {
@@ -352,6 +373,7 @@ int main(int argc, char* argv[]) {
             * size: "normal", "large"
             */
             drawitem_t drawitem;
+            XColor main_color;
             for (JsonNode* node = v->value.toNode(); node != nullptr; node = node->next) {
                 /* cout << "got key: " << node->key << endl; */
                 // common
@@ -397,43 +419,13 @@ int main(int argc, char* argv[]) {
                 } else {
                     XSetFont(g_display, gc, normalfont->fid);
                 }
-                if (drawitem.text.color[0] == '#') {
-                    unsigned int r, g, b;
-                    sscanf(drawitem.text.color, "#%02x%02x%02x", &r, &g, &b);
-                    XSetForeground(g_display, gc, createXColorFromRGBA(r, g, b, 255).pixel);
-                } else if (strcmp(drawitem.text.color, "red") == 0) {
-                    XSetForeground(g_display, gc, red.pixel);
-                } else if (strcmp(drawitem.text.color, "green") == 0) {
-                    XSetForeground(g_display, gc, green.pixel);
-                } else if (strcmp(drawitem.text.color, "yellow") == 0) {
-                    XSetForeground(g_display, gc, yellow.pixel);
-                } else if (strcmp(drawitem.text.color, "blue") == 0) {
-                    XSetForeground(g_display, gc, blue.pixel);
-                } else if (strcmp(drawitem.text.color, "black") == 0) {
-                    XSetForeground(g_display, gc, black.pixel);
-                } else {
-                    XSetForeground(g_display, gc, white.pixel);
-                }
+                main_color = get_color(drawitem.text.color);
+                XSetForeground(g_display, gc, main_color.pixel);
                 XDrawString(g_display, g_win, gc, SCALE_X(drawitem.text.x), SCALE_Y(drawitem.text.y), drawitem.text.text, strlen(drawitem.text.text));
             } else {
                 /* cout << "edmcoverlay2: drawing a shape" << endl; */
-                if (drawitem.shape.color[0] == '#') {
-                    unsigned int r, g, b;
-                    sscanf(drawitem.shape.color, "#%02x%02x%02x", &r, &g, &b);
-                    XSetForeground(g_display, gc, createXColorFromRGBA(r, g, b, 255).pixel);
-                } else if (strcmp(drawitem.shape.color, "red") == 0) {
-                    XSetForeground(g_display, gc, red.pixel);
-                } else if (strcmp(drawitem.shape.color, "green") == 0) {
-                    XSetForeground(g_display, gc, green.pixel);
-                } else if (strcmp(drawitem.shape.color, "yellow") == 0) {
-                    XSetForeground(g_display, gc, yellow.pixel);
-                } else if (strcmp(drawitem.shape.color, "blue") == 0) {
-                    XSetForeground(g_display, gc, blue.pixel);
-                } else if (strcmp(drawitem.shape.color, "black") == 0) {
-                    XSetForeground(g_display, gc, black.pixel);
-                } else {
-                    XSetForeground(g_display, gc, white.pixel);
-                }
+                main_color = get_color(drawitem.shape.color);
+                XSetForeground(g_display, gc, main_color.pixel);
                 if (strcmp(drawitem.shape.shape, "rect") == 0) {
                     /* cout << "edmcoverlay2: specifically, a rect" << endl; */
                     // TODO distinct fill/edge colour
@@ -467,39 +459,23 @@ int main(int argc, char* argv[]) {
                         }
 
                         if (strcmp(color, "") != 0) {
-                            if (color[0] == '#') {
-                                unsigned int r, g, b;
-                                sscanf(color, "#%02x%02x%02x", &r, &g, &b);
-                                XSetForeground(g_display, gc, createXColorFromRGBA(r, g, b, 255).pixel);
-                            } else if (strcmp(color, "red") == 0) {
-                                XSetForeground(g_display, gc, red.pixel);
-                            } else if (strcmp(color, "green") == 0) {
-                                XSetForeground(g_display, gc, green.pixel);
-                            } else if (strcmp(color, "yellow") == 0) {
-                                XSetForeground(g_display, gc, yellow.pixel);
-                            } else if (strcmp(color, "blue") == 0) {
-                                XSetForeground(g_display, gc, blue.pixel);
-                            } else if (strcmp(color, "black") == 0) {
-                                XSetForeground(g_display, gc, black.pixel);
-                            } else {
-                                XSetForeground(g_display, gc, white.pixel);
+                            XColor marker_color = get_color(color);
+                            XSetForeground(g_display, gc, marker_color.pixel);
+                            if (type != nullptr) {
+                                if (strcmp(type, "circle") == 0) {
+                                    XDrawArc(g_display, g_win, gc, SCALE_X(x)-4, SCALE_Y(y)-4, 8, 8, 0, 360*64);
+                                }
                             }
-                        }
+                            if (type != nullptr) {
+                                if (strcmp(type, "cross") == 0) {
+                                    XDrawLine(g_display, g_win, gc, SCALE_X(x)-4, SCALE_Y(y)-4, SCALE_X(x)+4, SCALE_Y(y)+4);
+                                    XDrawLine(g_display, g_win, gc, SCALE_X(x)-4, SCALE_Y(y)+4, SCALE_X(x)+4, SCALE_Y(y)-4);
+                                }
+                            }
 
-                        if (type != nullptr) {
-                            if (strcmp(type, "circle") == 0) {
-                                XDrawArc(g_display, g_win, gc, SCALE_X(x)-4, SCALE_Y(y)-4, 8, 8, 0, 360*64);
+                            if (text != nullptr && strcmp(text, "") != 0) {
+                                XDrawString(g_display, g_win, gc, SCALE_X(x+10), SCALE_Y(y+20), text, strlen(text));
                             }
-                        }
-                        if (type != nullptr) {
-                            if (strcmp(type, "cross") == 0) {
-                                XDrawLine(g_display, g_win, gc, SCALE_X(x)-4, SCALE_Y(y)-4, SCALE_X(x)+4, SCALE_Y(y)+4);
-                                XDrawLine(g_display, g_win, gc, SCALE_X(x)-4, SCALE_Y(y)+4, SCALE_X(x)+4, SCALE_Y(y)-4);
-                            }
-                        }
-
-                        if (text != nullptr && strcmp(text, "") != 0) {
-                            XDrawString(g_display, g_win, gc, SCALE_X(x+10), SCALE_Y(y+20), text, strlen(text));
                         }
                         type = "";
                         text = "";
@@ -510,6 +486,7 @@ int main(int argc, char* argv[]) {
                             y1 = y;
                             continue;
                         }
+                        XSetForeground(g_display, gc, main_color.pixel);
                         if (x2 == UNINIT_COORD) {
                             x2 = x;
                             y2 = y;

--- a/X11/overlay.cpp
+++ b/X11/overlay.cpp
@@ -444,16 +444,67 @@ int main(int argc, char* argv[]) {
 #define UNINIT_COORD 1000000
                     int x1 = UNINIT_COORD, y1 = UNINIT_COORD, x2 = UNINIT_COORD, y2 = UNINIT_COORD;
                     JsonNode* vect_ = drawitem.shape.vect;
+                    XSetFont(g_display, gc, normalfont->fid);
                     for (JsonNode* node_ = vect_; node_ != nullptr; node_ = node_->next) {
                         // node_ is a point
                         int x, y;
+                        char* color = "";
+                        char* type;
+                        char* text;
+
                         for (auto z : node_->value) {
                             if (strcmp(z->key, "x") == 0) {
                                 x = z->value.toNumber();
                             } else if (strcmp(z->key, "y") == 0) {
                                 y = z->value.toNumber();
+                            } else if (strcmp(z->key ,"color") == 0) {
+                                color = z->value.toString();
+                            } else if (strcmp(z->key, "marker") == 0) {
+                                type = z->value.toString();
+                            } else if (strcmp(z->key, "text") == 0) {
+                                text = z->value.toString();
                             }
                         }
+
+                        if (strcmp(color, "") != 0) {
+                            if (color[0] == '#') {
+                                unsigned int r, g, b;
+                                sscanf(color, "#%02x%02x%02x", &r, &g, &b);
+                                XSetForeground(g_display, gc, createXColorFromRGBA(r, g, b, 255).pixel);
+                            } else if (strcmp(color, "red") == 0) {
+                                XSetForeground(g_display, gc, red.pixel);
+                            } else if (strcmp(color, "green") == 0) {
+                                XSetForeground(g_display, gc, green.pixel);
+                            } else if (strcmp(color, "yellow") == 0) {
+                                XSetForeground(g_display, gc, yellow.pixel);
+                            } else if (strcmp(color, "blue") == 0) {
+                                XSetForeground(g_display, gc, blue.pixel);
+                            } else if (strcmp(color, "black") == 0) {
+                                XSetForeground(g_display, gc, black.pixel);
+                            } else {
+                                XSetForeground(g_display, gc, white.pixel);
+                            }
+                        }
+
+                        if (type != nullptr) {
+                            if (strcmp(type, "circle") == 0) {
+                                XDrawArc(g_display, g_win, gc, SCALE_X(x)-4, SCALE_Y(y)-4, 8, 8, 0, 360*64);
+                            }
+                        }
+                        if (type != nullptr) {
+                            if (strcmp(type, "cross") == 0) {
+                                XDrawLine(g_display, g_win, gc, SCALE_X(x)-4, SCALE_Y(y)-4, SCALE_X(x)+4, SCALE_Y(y)+4);
+                                XDrawLine(g_display, g_win, gc, SCALE_X(x)-4, SCALE_Y(y)+4, SCALE_X(x)+4, SCALE_Y(y)-4);
+                            }
+                        }
+
+                        if (text != nullptr && strcmp(text, "") != 0) {
+                            XDrawString(g_display, g_win, gc, SCALE_X(x+10), SCALE_Y(y+20), text, strlen(text));
+                        }
+                        type = "";
+                        text = "";
+                        color = "";
+
                         if (x1 == UNINIT_COORD) {
                             x1 = x;
                             y1 = y;


### PR DESCRIPTION
Base EDMCOverlay includes 'marker' and 'text' options in the 'vector' parameter. In addition, it contains another 'color' property that should be used instead of the top level color for these 'marker' elements.

(The main color is still used for the drawn lines.)