### PR TITLE
Parse alpha channel properly

### DIFF
--- a/Wayland/renderer.py
+++ b/Wayland/renderer.py
@@ -180,6 +180,7 @@ class MessageRenderer(object):
         
         rgba = self._colors.get(color, None)
         if not rgba:
+            rgba = Gdk.RGBA()
             color_code = re.match('#([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})?', color)
             if color_code:
                 color_groups = color_code.groups()
@@ -194,10 +195,9 @@ class MessageRenderer(object):
                     b = color_groups[3]
                     a = color_groups[0]
                 try:
-                    rgba = Gdk.RGBA()
                     rgba.parse(f'#{r}{g}{b}{a}')
                     self._colors[color] = rgba
+                    return rgba
                 except Exception as e:
                     logging.error(f' renderer color error for {color}: {e}')
-                    rgba.parse('green')
-        return rgba
+        return self._colors.get('green')

--- a/Wayland/renderer.py
+++ b/Wayland/renderer.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 from math import pi
 
@@ -167,7 +168,8 @@ class MessageRenderer(object):
             ctx.line_to(x-3, y+3)
             ctx.stroke()
         elif marker == 'circle':
-            ctx.arc(x, y, 8, 0, 2*pi)
+            ctx.move_to(x, y-8)
+            ctx.arc(x-2, y-8, 4, 0, 2*pi)
             ctx.stroke()
         else:
             logging.error(f'unknown marker: {marker}')
@@ -176,13 +178,26 @@ class MessageRenderer(object):
         if color is None or color == '' or color == '#':
             return None
         
-        rgba = self._colors.get(color)
+        rgba = self._colors.get(color, None)
         if not rgba:
-            try:
-                rgba = Gdk.RGBA()
-                rgba.parse(color)
-                self._colors[color] = rgba
-            except Exception as e:
-                logging.error(f' renderer color error for {color}: {e}')
-                rgba.parse('green')
+            color_code = re.match('#([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})?', color)
+            if color_code:
+                color_groups = color_code.groups()
+                if not color_groups[3]:
+                    r = color_groups[0]
+                    g = color_groups[1]
+                    b = color_groups[2]
+                    a = 'ff'
+                else:
+                    r = color_groups[1]
+                    g = color_groups[2]
+                    b = color_groups[3]
+                    a = color_groups[0]
+                try:
+                    rgba = Gdk.RGBA()
+                    rgba.parse(f'#{r}{g}{b}{a}')
+                    self._colors[color] = rgba
+                except Exception as e:
+                    logging.error(f' renderer color error for {color}: {e}')
+                    rgba.parse('green')
         return rgba

--- a/Wayland/renderer.py
+++ b/Wayland/renderer.py
@@ -131,8 +131,8 @@ class MessageRenderer(object):
                     ctx,
                     point.get('color', color),
                     point['marker'],
-                    point['x']+2,
-                    point['y']+7)
+                    point['x'],
+                    point['y'])
                 ctx.restore()
             if 'text' in point:
                 ctx.save()
@@ -168,8 +168,8 @@ class MessageRenderer(object):
             ctx.line_to(x-3, y+3)
             ctx.stroke()
         elif marker == 'circle':
-            ctx.move_to(x, y-8)
-            ctx.arc(x-2, y-8, 4, 0, 2*pi)
+            ctx.move_to(x+6, y)
+            ctx.arc(x, y, 6, 0, 2*pi)
             ctx.stroke()
         else:
             logging.error(f'unknown marker: {marker}')
@@ -180,7 +180,6 @@ class MessageRenderer(object):
         
         rgba = self._colors.get(color, None)
         if not rgba:
-            rgba = Gdk.RGBA()
             color_code = re.match('#([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})?', color)
             if color_code:
                 color_groups = color_code.groups()
@@ -195,9 +194,10 @@ class MessageRenderer(object):
                     b = color_groups[3]
                     a = color_groups[0]
                 try:
+                    rgba = Gdk.RGBA()
                     rgba.parse(f'#{r}{g}{b}{a}')
                     self._colors[color] = rgba
-                    return rgba
                 except Exception as e:
                     logging.error(f' renderer color error for {color}: {e}')
-        return self._colors.get('green')
+                    rgba.parse('green')
+        return rgba

--- a/X11/overlay.cpp
+++ b/X11/overlay.cpp
@@ -134,7 +134,33 @@ XColor createXColorFromRGBA(short red, short green, short blue, short alpha) {
     *(&color.pixel) = ((*(&color.pixel)) & 0x00ffffff) | (alpha << 24);
     return color;
 }
-
+XColor parse_color(char* color_code) {
+    XColor color;
+    if (color_code[0] == '#') {
+        if (strlen(color_code) == 7)  {
+            unsigned int r, g, b;
+            sscanf(color_code, "#%2x%2x%2x", &r, &g, &b);
+            color = createXColorFromRGBA(r, g, b, 255);
+        } else if (strlen(color_code) == 9) {
+            unsigned int r, g, b, a;
+            sscanf(color_code, "#%2x%2x%2x%2x", &a, &r, &g, &b);
+            color = createXColorFromRGBA(r, g, b, a);
+        }
+    } else if (strcmp(color_code, "red") == 0) {
+        color = red;
+    } else if (strcmp(color_code, "green") == 0) {
+        color = green;
+    } else if (strcmp(color_code, "yellow") == 0) {
+        color = yellow;
+    } else if (strcmp(color_code, "blue") == 0) {
+        color = blue;
+    } else if (strcmp(color_code, "black") == 0) {
+        color = black;
+    } else {
+        color = white;
+    }
+    return color;
+}
 // Create a window
 void createShapedWindow() {
     XSetWindowAttributes wattr;
@@ -352,6 +378,7 @@ int main(int argc, char* argv[]) {
             * size: "normal", "large"
             */
             drawitem_t drawitem;
+            XColor main_color;
             for (JsonNode* node = v->value.toNode(); node != nullptr; node = node->next) {
                 /* cout << "got key: " << node->key << endl; */
                 // common
@@ -397,43 +424,13 @@ int main(int argc, char* argv[]) {
                 } else {
                     XSetFont(g_display, gc, normalfont->fid);
                 }
-                if (drawitem.text.color[0] == '#') {
-                    unsigned int r, g, b;
-                    sscanf(drawitem.text.color, "#%02x%02x%02x", &r, &g, &b);
-                    XSetForeground(g_display, gc, createXColorFromRGBA(r, g, b, 255).pixel);
-                } else if (strcmp(drawitem.text.color, "red") == 0) {
-                    XSetForeground(g_display, gc, red.pixel);
-                } else if (strcmp(drawitem.text.color, "green") == 0) {
-                    XSetForeground(g_display, gc, green.pixel);
-                } else if (strcmp(drawitem.text.color, "yellow") == 0) {
-                    XSetForeground(g_display, gc, yellow.pixel);
-                } else if (strcmp(drawitem.text.color, "blue") == 0) {
-                    XSetForeground(g_display, gc, blue.pixel);
-                } else if (strcmp(drawitem.text.color, "black") == 0) {
-                    XSetForeground(g_display, gc, black.pixel);
-                } else {
-                    XSetForeground(g_display, gc, white.pixel);
-                }
+                main_color = parse_color(drawitem.text.color);
+                XSetForeground(g_display, gc, main_color.pixel);
                 XDrawString(g_display, g_win, gc, SCALE_X(drawitem.text.x), SCALE_Y(drawitem.text.y), drawitem.text.text, strlen(drawitem.text.text));
             } else {
                 /* cout << "edmcoverlay2: drawing a shape" << endl; */
-                if (drawitem.shape.color[0] == '#') {
-                    unsigned int r, g, b;
-                    sscanf(drawitem.shape.color, "#%02x%02x%02x", &r, &g, &b);
-                    XSetForeground(g_display, gc, createXColorFromRGBA(r, g, b, 255).pixel);
-                } else if (strcmp(drawitem.shape.color, "red") == 0) {
-                    XSetForeground(g_display, gc, red.pixel);
-                } else if (strcmp(drawitem.shape.color, "green") == 0) {
-                    XSetForeground(g_display, gc, green.pixel);
-                } else if (strcmp(drawitem.shape.color, "yellow") == 0) {
-                    XSetForeground(g_display, gc, yellow.pixel);
-                } else if (strcmp(drawitem.shape.color, "blue") == 0) {
-                    XSetForeground(g_display, gc, blue.pixel);
-                } else if (strcmp(drawitem.shape.color, "black") == 0) {
-                    XSetForeground(g_display, gc, black.pixel);
-                } else {
-                    XSetForeground(g_display, gc, white.pixel);
-                }
+                main_color = parse_color(drawitem.shape.color);
+                XSetForeground(g_display, gc, main_color.pixel);
                 if (strcmp(drawitem.shape.shape, "rect") == 0) {
                     /* cout << "edmcoverlay2: specifically, a rect" << endl; */
                     // TODO distinct fill/edge colour


### PR DESCRIPTION
In the Wayland renderer, the Windows EDMCOverlay #aarrggbb format is improperly parsed as #rrggbbaa.

I've parsed and reordered the hex codes to do this properly.

In the X11 renderer, alpha color codes are not handled at all (it is parsed as #rrggbb and the last hex digit is ignored).

The X11 renderer doesn't actually support alpha for lines, but at least this gets the correct base color.